### PR TITLE
Update UI theme to orange and switch to light mode

### DIFF
--- a/frontend/AIPodcast/AIPodcastApp.swift
+++ b/frontend/AIPodcast/AIPodcastApp.swift
@@ -12,7 +12,7 @@ struct AIPodcastApp: App {
     var body: some Scene {
         WindowGroup {
             MainTabView()
-                .preferredColorScheme(.dark)
+                .preferredColorScheme(.light)
         }
     }
 }

--- a/frontend/AIPodcast/Utilities/DesignSystem.swift
+++ b/frontend/AIPodcast/Utilities/DesignSystem.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 // MARK: Colors
 extension Color {
-    static let appPrimary = Color.blue
+    static let appOrange = Color(red: 252/255, green: 161/255, blue: 49/255)
+    
+    static let appPrimary = appOrange
     static let appSecondary = Color.gray
-    static let appAccent = Color.purple
+    static let appAccent = appOrange
     
     static let appBackground = Color(.systemBackground)
     static let appSecondaryBackground = Color(.secondarySystemBackground)
@@ -81,4 +83,3 @@ extension View {
         self.shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)
     }
 }
-

--- a/frontend/AIPodcast/Views/Documents/DocumentListView.swift
+++ b/frontend/AIPodcast/Views/Documents/DocumentListView.swift
@@ -15,7 +15,7 @@ struct DocumentListView: View {
                     GenerateTabView()
                 } label: {
                     Label("Upload PDFs to Generate", systemImage: "arrow.up.doc")
-                        .foregroundColor(.blue)
+                        .foregroundColor(.appOrange)
                 }
             }
             
@@ -23,7 +23,7 @@ struct DocumentListView: View {
                 ForEach(placeholderDocuments, id: \.self) { document in
                     HStack {
                         Image(systemName: "doc.text")
-                            .foregroundColor(.blue)
+                            .foregroundColor(.appOrange)
                         Text(document)
                     }
                 }

--- a/frontend/AIPodcast/Views/Generate/AddFileBox.swift
+++ b/frontend/AIPodcast/Views/Generate/AddFileBox.swift
@@ -6,7 +6,7 @@ struct AddFileBox: View {
     var body: some View {
         Button(action: onAddFile) {
             VStack(spacing: 12) {
-                // Blue circle with plus icon
+                // Orange circle with plus icon
                 ZStack {
                     Circle()
                         .fill(Color.appPrimary)
@@ -19,7 +19,7 @@ struct AddFileBox: View {
                 
                 Text("Add file")
                     .font(.headline)
-                    .foregroundColor(.white)
+                    .foregroundColor(.black)
                 
                 Text("Add files to generate your personalized\npodcast")
                     .font(.caption)
@@ -40,7 +40,7 @@ struct AddFileBox: View {
 
 #Preview {
     ZStack {
-        Color.black.ignoresSafeArea()
+        Color.white.ignoresSafeArea()
         AddFileBox(onAddFile: {})
             .padding()
     }

--- a/frontend/AIPodcast/Views/Generate/AddFileEmptyState.swift
+++ b/frontend/AIPodcast/Views/Generate/AddFileEmptyState.swift
@@ -7,7 +7,7 @@ struct AddFileEmptyState: View {
         Button(action: onAddFile) {
             VStack(spacing: 16) {
                 VStack(spacing: 12) {
-                    // Blue circle with plus icon
+                    // Orange circle with plus icon
                     ZStack {
                         Circle()
                             .fill(Color.appPrimary)
@@ -21,11 +21,11 @@ struct AddFileEmptyState: View {
                     Text("Add file")
                         .font(.title3)
                         .fontWeight(.semibold)
-                        .foregroundColor(.white)
+                        .foregroundColor(.appText)
                     
                     Text("Add file(s) to generate your personalized\npodcast")
                         .font(.subheadline)
-                        .foregroundColor(.gray)
+                        .foregroundColor(.appSecondaryText)
                         .multilineTextAlignment(.center)
                 }
             }
@@ -38,7 +38,7 @@ struct AddFileEmptyState: View {
 
 #Preview {
     ZStack {
-        Color.black.ignoresSafeArea()
+        Color.appBackground.ignoresSafeArea()
         AddFileEmptyState(onAddFile: {})
     }
 }

--- a/frontend/AIPodcast/Views/Generate/FileListView.swift
+++ b/frontend/AIPodcast/Views/Generate/FileListView.swift
@@ -29,7 +29,7 @@ struct FileListView: View {
 
 #Preview {
     ZStack {
-        Color.black.ignoresSafeArea()
+        Color.white.ignoresSafeArea()
         
         FileListView(
             files: [

--- a/frontend/AIPodcast/Views/Generate/GenerateTabView.swift
+++ b/frontend/AIPodcast/Views/Generate/GenerateTabView.swift
@@ -8,8 +8,7 @@ struct GenerateTabView: View {
         NavigationStack {
             ZStack {
                 // Dark background
-                Color.black.ignoresSafeArea()
-
+                Color.appBackground.ignoresSafeArea()
                 VStack(spacing: 0) {
                     // Main content area
                     if viewModel.selectedFiles.isEmpty {
@@ -52,9 +51,6 @@ struct GenerateTabView: View {
             }
             .navigationTitle("Generate")
             .navigationBarTitleDisplayMode(.large)
-            .toolbarBackground(Color.black, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
-            .toolbarColorScheme(.dark, for: .navigationBar)
             .fileImporter(
                 isPresented: $viewModel.showFilePicker,
                 allowedContentTypes: [.pdf],

--- a/frontend/AIPodcast/Views/Generate/LoadingOverlay.swift
+++ b/frontend/AIPodcast/Views/Generate/LoadingOverlay.swift
@@ -34,8 +34,8 @@ struct LoadingOverlay: View {
     
     var body: some View {
         ZStack {
-            // Full black screen overlay
-            Color.black
+            // Orange background overlay
+            Color.appOrange
                 .ignoresSafeArea()
             
             VStack(spacing: 0) {
@@ -46,7 +46,7 @@ struct LoadingOverlay: View {
                     // Icon
                     Image(systemName: tips[currentTipIndex].icon)
                         .font(.system(size: 60))
-                        .foregroundColor(.blue)
+                        .foregroundColor(.white)
                         .transition(.opacity)
                     
                     // Title
@@ -60,7 +60,7 @@ struct LoadingOverlay: View {
                     // Description
                     Text(tips[currentTipIndex].description)
                         .font(.body)
-                        .foregroundColor(.gray)
+                        .foregroundColor(.white.opacity(0.9))
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 40)
                         .transition(.opacity)
@@ -77,14 +77,14 @@ struct LoadingOverlay: View {
                     
                     GeometryReader { geometry in
                         ZStack(alignment: .leading) {
-                            // Background
+                            // Background track
                             RoundedRectangle(cornerRadius: 10)
-                                .fill(Color.gray.opacity(0.3))
+                                .fill(Color.white.opacity(0.3))
                                 .frame(height: 8)
                             
                             // Progress fill
                             RoundedRectangle(cornerRadius: 10)
-                                .fill(Color.blue)
+                                .fill(Color.white)
                                 .frame(width: geometry.size.width * progress, height: 8)
                                 .animation(.linear(duration: 0.3), value: progress)
                         }

--- a/frontend/AIPodcast/Views/Generate/LoadingOverlay.swift
+++ b/frontend/AIPodcast/Views/Generate/LoadingOverlay.swift
@@ -34,8 +34,8 @@ struct LoadingOverlay: View {
     
     var body: some View {
         ZStack {
-            // Orange background overlay
-            Color.appOrange
+            // White background overlay
+            Color.white
                 .ignoresSafeArea()
             
             VStack(spacing: 0) {
@@ -46,21 +46,21 @@ struct LoadingOverlay: View {
                     // Icon
                     Image(systemName: tips[currentTipIndex].icon)
                         .font(.system(size: 60))
-                        .foregroundColor(.white)
+                        .foregroundColor(.appOrange)
                         .transition(.opacity)
                     
                     // Title
                     Text(tips[currentTipIndex].title)
                         .font(.title2)
                         .fontWeight(.bold)
-                        .foregroundColor(.white)
+                        .foregroundColor(.appOrange)
                         .multilineTextAlignment(.center)
                         .transition(.opacity)
                     
                     // Description
                     Text(tips[currentTipIndex].description)
                         .font(.body)
-                        .foregroundColor(.white.opacity(0.9))
+                        .foregroundColor(.appOrange.opacity(0.9))
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 40)
                         .transition(.opacity)
@@ -73,18 +73,18 @@ struct LoadingOverlay: View {
                 VStack(spacing: 12) {
                     Text("Generating your podcast...")
                         .font(.subheadline)
-                        .foregroundColor(.white)
+                        .foregroundColor(.appOrange)
                     
                     GeometryReader { geometry in
                         ZStack(alignment: .leading) {
                             // Background track
                             RoundedRectangle(cornerRadius: 10)
-                                .fill(Color.white.opacity(0.3))
+                                .fill(Color.appOrange.opacity(0.3))
                                 .frame(height: 8)
                             
                             // Progress fill
                             RoundedRectangle(cornerRadius: 10)
-                                .fill(Color.white)
+                                .fill(Color.appOrange)
                                 .frame(width: geometry.size.width * progress, height: 8)
                                 .animation(.linear(duration: 0.3), value: progress)
                         }

--- a/frontend/AIPodcast/Views/Home/HomeTabView.swift
+++ b/frontend/AIPodcast/Views/Home/HomeTabView.swift
@@ -11,19 +11,19 @@ struct HomeTabView: View {
                     HStack(spacing: 10) {
                         Image(systemName: "waveform.circle.fill")
                             .font(.system(size: 28))
-                            .foregroundColor(.blue)
+                            .foregroundColor(.appOrange)
                         
                         Text("PROJ430")
                             .font(.largeTitle)
                             .fontWeight(.bold)
-                            .foregroundColor(.white)
+                            .foregroundColor(.appText)
                         
                         Spacer()
                     }
                     .padding(.horizontal, 20)
                     .padding(.top, 60)
                     .padding(.bottom, 8)
-                    .background(Color.black)
+                    .background(Color.appBackground)
                     
                     Group {
                         if appState.generatedPodcasts.isEmpty && appState.downloadedPodcasts.isEmpty {
@@ -34,7 +34,7 @@ struct HomeTabView: View {
                     }
                 }
                 .navigationBarHidden(true)
-                .background(Color.black.ignoresSafeArea())
+                .background(Color.appBackground.ignoresSafeArea())
             }
         } else {
             NavigationView {

--- a/frontend/AIPodcast/Views/Home/UnpopulatedHomeView.swift
+++ b/frontend/AIPodcast/Views/Home/UnpopulatedHomeView.swift
@@ -8,7 +8,7 @@ struct UnpopulatedHomeView: View {
     
     var body: some View {
         ZStack {
-            Color.black.ignoresSafeArea()
+            Color.appBackground.ignoresSafeArea()
             
             VStack(spacing: 0) {
                 Spacer()

--- a/frontend/AIPodcast/Views/MainTabView.swift
+++ b/frontend/AIPodcast/Views/MainTabView.swift
@@ -17,6 +17,8 @@ struct MainTabView: View {
                 }
                 .tag(Tab.generate)
         }
+        .tint(.appOrange)
+        .preferredColorScheme(.light)
         .sheet(item: $appState.selectedPodcast) { podcast in
             PodcastPlayerView(podcast: podcast)
         }

--- a/frontend/AIPodcast/Views/Player/AskAISection.swift
+++ b/frontend/AIPodcast/Views/Player/AskAISection.swift
@@ -19,7 +19,7 @@ struct AskAISection: View {
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
-                .background(Color.blue)
+                .background(Color.appOrange)
                 .cornerRadius(12)
             }
             .disabled(isProcessing)
@@ -35,7 +35,7 @@ struct AskAISection: View {
                         ProgressView()
                     } else {
                         Image(systemName: "paperplane.fill")
-                            .foregroundColor(.blue)
+                            .foregroundColor(.appOrange)
                     }
             }
             .disabled(question.isEmpty || isProcessing)

--- a/frontend/AIPodcast/Views/Player/PlaybackControlsView.swift
+++ b/frontend/AIPodcast/Views/Player/PlaybackControlsView.swift
@@ -12,7 +12,7 @@ struct PlaybackControlsView: View {
             Button(action: onPlayPause) {
                 Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
                     .font(.system(size: 70))
-                    .foregroundColor(.blue)
+                    .foregroundColor(.appOrange)
             }
             
             Spacer()

--- a/frontend/AIPodcast/Views/Player/ProgressBarView.swift
+++ b/frontend/AIPodcast/Views/Player/ProgressBarView.swift
@@ -16,7 +16,7 @@ struct ProgressBarView: View {
                     
                     // Progress
                     RoundedRectangle(cornerRadius: 2)
-                        .fill(Color.blue)
+                        .fill(Color.appOrange)
                         .frame(width: progressWidth(geometry: geometry), height: 4)
                 }
             }

--- a/frontend/AIPodcast/Views/Shared/ButtonStyles.swift
+++ b/frontend/AIPodcast/Views/Shared/ButtonStyles.swift
@@ -277,6 +277,6 @@ struct BareIconButtonStyle: ButtonStyle {
             }
         }
         .padding()
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(.light)
     }
 }

--- a/frontend/AIPodcast/Views/Shared/DocumentCard.swift
+++ b/frontend/AIPodcast/Views/Shared/DocumentCard.swift
@@ -61,7 +61,7 @@ struct DocumentCard: View {
             ZStack {
                 Image(systemName: status.documentIcon)
                     .font(.system(size: 20))
-                    .foregroundColor(.white)
+                    .foregroundColor(.appPrimary)
                 
                 // Circular Progress Overlay (only for uploading)
                 if case .uploading(let progress) = status {
@@ -75,14 +75,14 @@ struct DocumentCard: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(filename)
                     .font(.appBody)
-                    .foregroundColor(.white)
+                    .foregroundColor(.appText)
                     .lineLimit(1)
                 
                 // Show date only if provided (for library view)
                 if let uploadDate = uploadDate {
                     Text(formattedDate(uploadDate))
                         .font(.appCaption)
-                        .foregroundColor(.white.opacity(0.7))
+                        .foregroundColor(.appSecondaryText)
                 }
             }
             
@@ -92,20 +92,20 @@ struct DocumentCard: View {
             if let size = fileSize {
                 Text(size)
                     .font(.appBody)
-                    .foregroundColor(.white)
+                    .foregroundColor(.appSecondaryText)  // Changed from .white
             }
             
             // Delete button (X)
             Button(action: onDelete) {
                 Image(systemName: "xmark")
             }
-            .buttonStyle(BareIconButtonStyle(tintColor: .gray, size: .mini))
+            .buttonStyle(BareIconButtonStyle(tintColor: .appSecondaryText, size: .mini))
         }
         .padding(.vertical, 12)
         .padding(.horizontal, 16)
         .background(
             RoundedRectangle(cornerRadius: 8)
-                .fill(Color.white.opacity(0.1))
+                .fill(Color.appSecondaryBackground)
         )
         
         // Wrap in button only if onTap is provided
@@ -135,7 +135,7 @@ struct CircularProgressView: View {
             // Background circle
             Circle()
                 .stroke(
-                    Color.white.opacity(0.2),
+                    Color.appSecondaryText.opacity(0.3),
                     lineWidth: 2
                 )
             
@@ -143,7 +143,7 @@ struct CircularProgressView: View {
             Circle()
                 .trim(from: 0, to: progress)
                 .stroke(
-                    Color.appWarning,
+                    Color.appOrange,
                     style: StrokeStyle(
                         lineWidth: 2,
                         lineCap: .round
@@ -156,14 +156,14 @@ struct CircularProgressView: View {
 }
 
 // MARK: Previews
-#Preview("Document Cards - Dark Mode") {
+#Preview("Document Cards - Light Mode") {
     ZStack {
-        Color.black.ignoresSafeArea()
+        Color.appBackground.ignoresSafeArea()
         
         VStack(spacing: Spacing.md) {
             Text("Document Cards")
                 .font(.appTitle)
-                .foregroundColor(.white)
+                .foregroundColor(.appText)
                 .padding(.bottom, Spacing.sm)
             
             DocumentCard(
@@ -188,6 +188,6 @@ struct CircularProgressView: View {
             )
         }
         .padding()
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(.light)
     }
 }

--- a/frontend/AIPodcast/Views/Shared/EmptyStateView.swift
+++ b/frontend/AIPodcast/Views/Shared/EmptyStateView.swift
@@ -182,7 +182,7 @@ extension EmptyStateView {
                 .frame(height: 400)
         }
     }
-    .preferredColorScheme(.dark)
+    .preferredColorScheme(.light)
 }
 
 #Preview("Compact Empty State") {

--- a/frontend/AIPodcast/Views/Shared/LoadingView.swift
+++ b/frontend/AIPodcast/Views/Shared/LoadingView.swift
@@ -175,5 +175,5 @@ struct SkeletonLoadingView: View {
         .padding(.horizontal)
     }
     .padding()
-    .preferredColorScheme(.dark)
+    .preferredColorScheme(.light)
 }

--- a/frontend/AIPodcast/Views/Shared/PodcastCard.swift
+++ b/frontend/AIPodcast/Views/Shared/PodcastCard.swift
@@ -267,6 +267,6 @@ struct LargePodcastCard: View {
         )
     }
     .padding()
-    .preferredColorScheme(.dark)
+    .preferredColorScheme(.light)
 }
 


### PR DESCRIPTION
- Changed primary and accent colors from blue to orange (#FCA131)
- Switched app from dark mode to light mode
- Updated all hardcoded colors to use theme system
- Updated LoadingOverlay with orange background and white icons
- Updated tab bar icons to use orange accent color
- Updated DocumentCard, HomeTabView, and other components for light mode
<img width="201" height="437" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-19 at 14 36 25" src="https://github.com/user-attachments/assets/0d87a5a9-d286-414c-a3d5-33b6e76d5039" />
<img width="233" height="470" alt="Screenshot 2026-01-19 at 2 25 33 PM" src="https://github.com/user-attachments/assets/42569fea-80f9-424c-ac63-9557721729e7" />
